### PR TITLE
fix cache key and config

### DIFF
--- a/src/Core/Configure/Engine/DbConfig.php
+++ b/src/Core/Configure/Engine/DbConfig.php
@@ -68,8 +68,8 @@ class DbConfig implements ConfigEngineInterface
                 $this->_table->aliasField('namespace') => $key
             ])
             ->cache(function ($q) {
-                return md5(serialize($q->clause('where')), $this->_cacheConfig);
-            })
+                return md5(serialize($q->clause('where')));
+            }, $this->_cacheConfig)
             ->toArray();
     }
 


### PR DESCRIPTION
cacheConfig was going to `md5()` second param rather then `cache()` second param.
