### PR TITLE
check key without namespace before array union

### DIFF
--- a/src/Model/Table/AbstractConfigurationsTable.php
+++ b/src/Model/Table/AbstractConfigurationsTable.php
@@ -25,7 +25,7 @@ abstract class AbstractConfigurationsTable extends Table implements Configuratio
             ->formatResults(function ($results) {
                 $resultSet = $results->toArray();
                 if (isset($resultSet[''])) {
-                    $resultSet = array_merge($resultSet, $resultSet['']);
+                    $resultSet += $resultSet[''];
                     unset($resultSet['']);
                 }
                 return $resultSet;

--- a/src/Model/Table/AbstractConfigurationsTable.php
+++ b/src/Model/Table/AbstractConfigurationsTable.php
@@ -24,8 +24,10 @@ abstract class AbstractConfigurationsTable extends Table implements Configuratio
             ])
             ->formatResults(function ($results) {
                 $resultSet = $results->toArray();
-                $resultSet += $resultSet[''];
-                unset($resultSet['']);
+                if (isset($resultSet[''])) {
+                    $resultSet = array_merge($resultSet, $resultSet['']);
+                    unset($resultSet['']);
+                }
                 return $resultSet;
             });
     }


### PR DESCRIPTION
PHP7 now checks var type before merging array with `+=` operand, changed to `array_merge()` instead
