### PR TITLE
introduces a special  value to load all namespaces, changes where cla…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "cakephp/cakephp": "~3.0"
     }
     , "require-dev": {
-        "phpunit/phpunit": "4.1.*"
+        "phpunit/phpunit": "4.1.*",
+        "cakephp/cakephp-codesniffer": "^2.1"
     }
     , "autoload": {
         "psr-4": {

--- a/src/Core/Configure/Engine/DbConfig.php
+++ b/src/Core/Configure/Engine/DbConfig.php
@@ -62,11 +62,15 @@ class DbConfig implements ConfigEngineInterface
      */
     public function read($key)
     {
-        return $this->_table
-            ->find('kv')
-            ->where([
-                $this->_table->aliasField('namespace') => $key
-            ])
+        $query = $this->_table->find('kv');
+
+        if ($key !== '*') {
+            $query->where([
+                $this->_table->aliasField('namespace') . ' IS' => $key
+            ]);
+        }
+
+        return $query
             ->cache(function ($q) {
                 return md5(serialize($q->clause('where')));
             }, $this->_cacheConfig)

--- a/src/Core/Configure/Engine/DbConfig.php
+++ b/src/Core/Configure/Engine/DbConfig.php
@@ -62,11 +62,15 @@ class DbConfig implements ConfigEngineInterface
      */
     public function read($key)
     {
-        return $this->_table
-            ->find('kv')
-            ->where([
-                $this->_table->aliasField('namespace') => $key
-            ])
+        $query = $this->_table->find('kv');
+
+        if ($key !== '*') {
+            $query->where([
+                $this->_table->aliasField('namespace') . ' IS' => $key
+            ]);
+        }
+
+        return $query
             ->cache(function ($q) {
                 return md5(serialize($q->clause('where')), $this->_cacheConfig);
             })

--- a/src/Core/Configure/Engine/DbConfig.php
+++ b/src/Core/Configure/Engine/DbConfig.php
@@ -89,6 +89,7 @@ class DbConfig implements ConfigEngineInterface
         $data = Hash::flatten($data);
         array_walk($data, [$this, '_persist'], $key);
         array_filter($data);
+
         return (bool)$data;
     }
 

--- a/src/Core/Configure/Engine/DbConfig.php
+++ b/src/Core/Configure/Engine/DbConfig.php
@@ -68,8 +68,8 @@ class DbConfig implements ConfigEngineInterface
                 $this->_table->aliasField('namespace') => $key
             ])
             ->cache(function ($q) {
-                return md5(serialize($q->clause('where')), $this->_cacheConfig);
-            })
+                return md5(serialize($q->clause('where')));
+            }, $this->_cacheConfig)
             ->toArray();
     }
 

--- a/src/Model/Table/AbstractConfigurationsTable.php
+++ b/src/Model/Table/AbstractConfigurationsTable.php
@@ -25,7 +25,7 @@ abstract class AbstractConfigurationsTable extends Table implements Configuratio
             ->formatResults(function ($results) {
                 $resultSet = $results->toArray();
                 if (isset($resultSet[''])) {
-                    $resultSet = array_merge($resultSet, $resultSet['']);
+                    $resultSet += $resultSet[''];
                     unset($resultSet['']);
                 }
                 return $resultSet;

--- a/src/Model/Table/AbstractConfigurationsTable.php
+++ b/src/Model/Table/AbstractConfigurationsTable.php
@@ -24,8 +24,10 @@ abstract class AbstractConfigurationsTable extends Table implements Configuratio
             ])
             ->formatResults(function ($results) {
                 $resultSet = $results->toArray();
-                $resultSet += $resultSet[''];
-                unset($resultSet['']);
+                if (isset($resultSet[''])) {
+                    $resultSet = array_merge($resultSet, $resultSet['']);
+                    unset($resultSet['']);
+                }
                 return $resultSet;
             });
     }

--- a/src/Model/Table/AbstractConfigurationsTable.php
+++ b/src/Model/Table/AbstractConfigurationsTable.php
@@ -26,6 +26,7 @@ abstract class AbstractConfigurationsTable extends Table implements Configuratio
                 $resultSet = $results->toArray();
                 $resultSet += $resultSet[''];
                 unset($resultSet['']);
+
                 return $resultSet;
             });
     }

--- a/src/Model/Table/AbstractConfigurationsTable.php
+++ b/src/Model/Table/AbstractConfigurationsTable.php
@@ -28,6 +28,7 @@ abstract class AbstractConfigurationsTable extends Table implements Configuratio
                     $resultSet += $resultSet[''];
                     unset($resultSet['']);
                 }
+
                 return $resultSet;
             });
     }

--- a/tests/TestCase/Core/Configure/Engine/DbConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/DbConfigTest.php
@@ -37,14 +37,10 @@ class DbConfigTest extends TestCase
                         'bar' => 'foobar',
                     ],
                 ];
-                break;
             case null:
                 return ['foz' => 'baz'];
-                break;
-
             case '*':
                 return $this->_config('Editable') + $this->_config(null);
-                break;
         }
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,7 @@ unset($findRoot);
 chdir($root);
 if (file_exists($root . '/config/bootstrap.php')) {
     require $root . '/config/bootstrap.php';
+
     return;
 }
 


### PR DESCRIPTION
Adds a special `$key` value (`*`) to load configurations from all namespaces, ie:
`Configure::load('*', 'db');`

Bonus:
Change where clause to work with `null` `$key` as well, so you can `Configure::load(null, 'db');` now.
